### PR TITLE
feat: add only failing test suites option

### DIFF
--- a/.changeset/large-bees-attend.md
+++ b/.changeset/large-bees-attend.md
@@ -1,0 +1,5 @@
+---
+"jest-console-group-reporter": minor
+---
+
+Add a new configuration option "onlyFailingTestSuites" to allow users to display console messages from only the failing test suites.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A Jest reporter that groups console messages, allows filtering, and provides fle
     - [afterEachTest](#aftereachtest)
     - [afterAllTests](#afteralltests)
     - [useGitHubActions](#usegithubactions)
+    - [onlyFailingTestSuites](#onlyFailingTestSuites)
   - [Summary Reporter](#summary-reporter)
 - [Known issues](#known-issues)
 
@@ -120,6 +121,7 @@ const defaultOptions: Options = {
   consoleLevels: ["error", "warn", "info", "debug", "log"],
   filters: [],
   groups: [],
+  onlyFailingTestSuites: false,
   afterEachTest: {
     enable: true,
     reportType: "summary",
@@ -361,6 +363,17 @@ const useGithubActions = process.env.IS_CI;
 module.exports = {
   // ...
   reporters: [["jest-console-group-reporter", { useGithubActions }]],
+};
+```
+
+### onlyFailingTestSuites
+
+This reporter shows console messages for all tests by default. Use the `onlyFailingTestSuites` option to see messages only for failing test suites. Due to Jest's limitations, messages can't be filtered for individual failing tests, only for the entire failing suites.
+
+```ts
+module.exports = {
+  // ...
+  reporters: [["jest-console-group-reporter", { onlyFailingTestSuites: true }]],
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky install",
     "test": "jest --colors",
+    "test:watch": "jest --watch --colors",
     "test:coverage": "jest --coverage",
     "build": "tsup",
     "type-check": "tsc --noEmit",

--- a/src/JestConsoleGroupReporter.ts
+++ b/src/JestConsoleGroupReporter.ts
@@ -65,16 +65,33 @@ export class JestConsoleGroupReporter extends DefaultReporter {
     config: Config.ProjectConfig,
     testResult: TestResult
   ): void {
-    const { consoleMessagesMap, filteredCount } = this.processTestResult(config, testResult);
-    this.storeConsoleMessages(consoleMessagesMap);
-    this.storeFilteredCount(filteredCount);
+    if (this.options.onlyFailingTestSuites && testResult.numFailingTests === 0) {
+      super.printTestFileHeader(testPath, config, this.stripConsoleMessagesFromResults(testResult));
+      return;
+    }
+
+    const processedTestResults = this.processTestResult(config, testResult);
+    this.storeMessages(processedTestResults);
     super.printTestFileHeader(testPath, config, this.stripConsoleMessagesFromResults(testResult));
     this.handleReporting({
-      consoleMessagesMap,
-      filteredCount,
+      ...processedTestResults,
       displayOption: this.options.afterEachTest,
       type: "afterEachTest",
     });
+  }
+
+  /**
+   * Store console messages and filter count.
+   */
+  private storeMessages({
+    consoleMessagesMap,
+    filteredCount,
+  }: {
+    consoleMessagesMap: ConsoleMessagesMap;
+    filteredCount: number;
+  }): void {
+    this.storeConsoleMessages(consoleMessagesMap);
+    this.storeFilteredCount(filteredCount);
   }
 
   /**

--- a/src/__test__/initializeOptions.spec.ts
+++ b/src/__test__/initializeOptions.spec.ts
@@ -7,6 +7,7 @@ describe("initializeOptions", () => {
     consoleLevels: ["error", "warn", "info", "debug", "log"],
     filters: [],
     groups: [],
+    onlyFailingTestSuites: false,
     afterEachTest: {
       reportType: "summary",
       enable: true,
@@ -53,6 +54,7 @@ describe("initializeOptions", () => {
 
   test("Should merge partial custom options with default options", () => {
     const customOptions = {
+      onlyFailingTestSuites: true,
       afterEachTest: {
         reportType: "detailed",
       },
@@ -60,6 +62,7 @@ describe("initializeOptions", () => {
 
     const expected = {
       ...defaultOptions,
+      onlyFailingTestSuites: true,
       afterEachTest: {
         ...defaultOptions.afterEachTest,
         reportType: "detailed",

--- a/src/initializeOptions.ts
+++ b/src/initializeOptions.ts
@@ -5,6 +5,7 @@ interface InitialReporterOptions {
   filters?: Options["filters"];
   groups?: Options["groups"];
   consoleLevels?: Options["consoleLevels"];
+  onlyFailingTestSuites?: boolean;
   afterEachTest?: {
     enabled?: boolean;
     reportType?: Options["afterAllTests"]["reportType"];
@@ -27,6 +28,7 @@ export function initializeOptions(initialOptions: InitialReporterOptions = {}): 
     consoleLevels: ["error", "warn", "info", "debug", "log"],
     filters: [],
     groups: [],
+    onlyFailingTestSuites: false,
     afterEachTest: {
       enable: true,
       reportType: "summary",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,7 @@ export interface DisplayOptions {
 export interface Options {
   filters: Array<Matcher>;
   groups: Array<{ match: Matcher; name: string | ((arg: ConsoleMessage) => string) }>;
+  onlyFailingTestSuites: boolean;
   consoleLevels: ConsoleTypes[];
   afterEachTest: DisplayOptions;
   afterAllTests: DisplayOptions;


### PR DESCRIPTION
Add a new configuration option "onlyFailingTestSuites" to allow users to display console messages from only the failing test suites.